### PR TITLE
FFQs, SR mask + shieldings, and small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,12 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
 project(FCCDetectors)
 
-
-#---------------------------------------------------------------
-find_package(DD4hep)
-#---------------------------------------------------------------
-
-
 include(GNUInstallDirs)
 include(CTest)
 
+# CMake variable setup------------------------------------------
+# Default for install prefix
+# ``-DCMAKE_INSTALL_PREFIX=<location>`` when invoking CMake
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/InstallArea/ CACHE PATH
     "Install path prefix, prepended onto install directories." FORCE )
@@ -19,17 +16,18 @@ endif()
 # Set up C++ Standard
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
 if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
-message(${CMAKE_MODULE_PATH})
+# Find CMake scripts
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-message(${CMAKE_MODULE_PATH})
+
+# Dependencies--------------------------------------------------
+find_package(DD4hep)
 
 
-
+# Environment  for tests----------------------------------------
 get_target_property(ddcore_lib DD4hep::DDCore LOCATION)
 get_filename_component(ddcore_loc ${ddcore_lib} DIRECTORY)
 function(k4_set_test_env _testname)
@@ -39,29 +37,19 @@ endforeach()
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_CURRENT_BINARY_DIR}:${ddcore_loc}:${_subdirs}:$ENV{LD_LIBRARY_PATH}")
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "ROOT_INCLUDE_PATH=${ddcore_loc}/../include:$ENV{ROOT_INCLUDE_PATH}")
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "DD4hepINSTALL=${ddcore_loc}/../")
-
 endfunction()
 
-
-
+# Subdirectories -----------------------------------------------
 add_subdirectory(Detector)
 
-# - install and export
+# Installation and export --------------------------------------
 install(FILES
   "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   )
-
-
-
-
-
 
 install(EXPORT ${PROJECT_NAME}Targets
   NAMESPACE ${PROJECT_NAME}::
   FILE "${PROJECT_NAME}Targets.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/"
   )
-
-#gaudi_install(CMAKE cmake/${PROJECT_NAME}Config.cmake)
-

--- a/Detector/DetFCCeeCLD/compact/FCCee_o2_v03/FCCee_DectDimensions.xml
+++ b/Detector/DetFCCeeCLD/compact/FCCee_o2_v03/FCCee_DectDimensions.xml
@@ -52,6 +52,7 @@
     <constant name="DetID_LumiCalBackShield"          value=" 18"/>
     <constant name="DetID_HOMAbsorber"          value=" 19"/>
     <constant name="DetID_LumiCalNoseShield"          value=" 22"/>
+    <constant name="DetID_FFQs"  value="23"/>
     
     <constant name="BeamPipeWidth"   	value="1.7*mm" /> <!-- 1.2*mm-->
     <constant name="BeamPipeWidthFirstCone"   	value="1.0*mm" />

--- a/Detector/DetFCCeeCLD/compact/FCCee_o2_v03/FCCee_o2_v03.xml
+++ b/Detector/DetFCCeeCLD/compact/FCCee_o2_v03/FCCee_o2_v03.xml
@@ -31,24 +31,28 @@
 
   <include ref="./FCCee_DectDimensions.xml" />
 
-  <include ref="../../../DetFCCeeCommon/compact/Beampipe.xml"/>
-  <include ref="../../../DetFCCeeCommon/compact/HOMAbsorber.xml"/>
+<include ref="../../../DetFCCeeCommon/compact/Beampipe_with_notch_noShield.xml"/>
+<!--  <include ref="../../../DetFCCeeCommon/compact/Beampipe_noShield.xml"/> -->
+<include ref="../../../DetFCCeeCommon/compact/SRshielding.xml"/>
   <include ref="../../../DetFCCeeCommon/compact/BeamInstrumentation.xml"/>
   <include ref="../../../DetFCCeeCommon/compact/LumiCal.xml"/>
 
-  <include ref="Vertex.xml"/> 
-  <include ref="InnerTracker.xml"/>
-  <include ref="OuterTracker.xml"/>
+  <include ref="Vertex.xml"/>  
+  <include ref="InnerTracker.xml"/> 
+  <include ref="OuterTracker.xml"/> 
 
   <include ref="ECalBarrel.xml"/>
   <include ref="ECalEndcap.xml"/>
 
-    <include ref="HCalBarrel.xml"/>
-    <include ref="HCalEndcap.xml"/>
+    <include ref="HCalBarrel.xml"/> 
+    <include ref="HCalEndcap.xml"/> 
     <include ref="Solenoid.xml"/>
 
     <include ref="YokeBarrel.xml"/>
     <include ref="YokeEndcap.xml"/>
-
+    
+  <include ref="../../../DetFCCeeCommon/compact/FFQuads_sens.xml"/>
+    <!--<include ref="../../../DetFCCeeCommon/compact/FFQuads.xml"/> -->
+    <!--<include ref="../../../DetFCCeeCommon/compact/HOMAbsorber.xml"/>-->
 
 </lccdd>

--- a/Detector/DetFCCeeCLD/compact/FCCee_o2_v03/additional_materials.xml
+++ b/Detector/DetFCCeeCLD/compact/FCCee_o2_v03/additional_materials.xml
@@ -53,6 +53,22 @@
       <fraction n="0.0142636698452849" ref="C"/>
       <fraction n="0.818763326226013" ref="Cu"/>
     </material>
+    
+    <material name="Paraffine" state="solid">
+      <D unit="g/cm3" value="0.8"/>
+      <fraction n="0.334" ref="C"/>
+      <fraction n="0.666" ref="H"/>
+    </material>
+    
+    <material name="FFQMaterial">
+      <D type="density" value="3.367" unit="g/cm3"/>
+      <fraction n="0.654058214" ref="Al"/>
+      <fraction n="0.03095534" ref="Nb"/>
+      <fraction n="0.03095534" ref="Ti"/>
+      <fraction n="0.117630293" ref="Cu"/>
+      <fraction n="0.097743288" ref="Paraffine"/>
+      <fraction n="0.068657524" ref="Kapton"/>
+    </material>
 
 </materials>
 

--- a/Detector/DetFCCeeCommon/compact/Beampipe_noShield.xml
+++ b/Detector/DetFCCeeCommon/compact/Beampipe_noShield.xml
@@ -1,0 +1,89 @@
+<lccdd>
+
+  <info name="FCCee"
+        title="FCCee Beam pipe: taken corresponding to CLD: Beampipe_o4_v04_noNotch_W_n02.xml"
+        author="from ILCSOFT/lcgeo/FCCee/compact/FCCee_o1_v04"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>A beampipe for FCCee</comment>
+  </info>
+
+    <!--  Definition of global dictionary constants          -->
+    <define>
+    <!--  Definition of global dictionary constants          -->
+      <constant name="beampipegoldwidth" value="BeamPipeGoldWidth"/>
+      <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
+        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
+    </display>
+    
+    <detectors>
+
+        <comment>Part of beampipe made of Beryllium</comment>
+        
+        <detector name="BeBeampipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" nocore="true" vis="BeamPipeVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax"  rMin2="CentralBeamPipe_rmax"    rMax1="CentralBeamPipe_rmax+BeamPipeWidth"  rMax2="CentralBeamPipe_rmax+BeamPipeWidth"                material="Beryllium" name="VertexInnerBe" />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="BePartEnd_z"  rMin1="CentralBeamPipe_rmax"  rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"      rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone"  rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017" material="Beryllium" name="FirstConeBe" />
+
+        </detector>
+
+	<detector name="BeamPipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" vis="BeamPipeVis" >
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <parameter crossingangle="CrossingAngle" />
+
+            <!--             &A                       Z1                  Z2                    RIn1                RIn2                                 ROut1                        ROut2                                              Material -->
+
+
+            <comment>Golden foil in the inner part of the Be beampipe</comment>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"    rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance"                material="Gold" name="VertexInnerGold"  />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="BePartEnd_z"  rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"      rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance+(BePartEnd_z-CentralBeamPipe_zmax)*0.017" material="Gold" name="FirstConeGold" />
+
+        <comment>Part of beampipe made of Copper</comment>
+        
+            <section type="Center" start="BePartEnd_z"  end="SeparatedBeamPipe_z"  
+		     rMin1="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  
+                     rMin2="SeparatedBeamPipe_rmax+0.015*SeparatedBeamPipe_z"      
+	             rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  
+                     rMax2="SeparatedBeamPipe_rmax+BeamPipeWidthFirstCone+0.015*SeparatedBeamPipe_z" 
+                     material="Copper" name="CopperCone" />
+<!--rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"
+    rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"-->  
+
+<!-- PunchedCenter = un volume qui s'etend jusqu'a rMax1 (a z=start) et rMax2 (a end) et avec deux cylindres extrudes le long
+        des directions up / down (depend du xing angle), de rayon rMin1 et rMin2  -->
+
+
+    <section type="PunchedCenter"        start="SeparatedBeamPipe_z" end="SeparatedBeamPipe_z+3*mm"    
+	     rMin1="SeparatedBeamPipe_rmax"      rMin2="SeparatedBeamPipe_rmax"       
+	     rMax1="SeparatedBeamPipe_rmax+0.015*(SeparatedBeamPipe_z+3*mm)"
+             rMax2="SeparatedBeamPipe_rmax+BeamPipeWidthFirstCone+0.015*(SeparatedBeamPipe_z+3*mm)" 
+             material="Copper"     name="SplitVacChambers"/>
+
+    <!-- Downstream pipe : first part : radius = 1.5 cm -->
+
+             <section type="DnstreamClippedFront" start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="DownStreamBeamPipe_1"/>
+
+          
+	        <section type="UpstreamClippedFront"  start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_1"/>
+
+	</detector>
+
+</detectors>
+</lccdd>

--- a/Detector/DetFCCeeCommon/compact/Beampipe_with_notch.xml
+++ b/Detector/DetFCCeeCommon/compact/Beampipe_with_notch.xml
@@ -1,0 +1,187 @@
+<lccdd>
+
+  <info name="FCCee"
+        title="FCCee Beam pipe: taken corresponding to CLD: Beampipe_o4_v04_noNotch_W_n02.xml"
+        author="nalipour taken from lcgeo"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>A beampipe for FCCee detector based on CLD</comment>
+  </info>
+    
+    <!--  Definition of global dictionary constants          -->
+    <define>
+      <constant name="beampipegoldwidth" value="BeamPipeGoldWidth"/>
+      <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
+        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
+    </display>
+    
+    
+    <detectors>
+
+        <comment>Part of beampipe made of Beryllium</comment>
+        
+        <detector name="BeBeampipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" nocore="true" vis="BeamPipeVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax"  rMin2="CentralBeamPipe_rmax"    rMax1="CentralBeamPipe_rmax+BeamPipeWidth"  rMax2="CentralBeamPipe_rmax+BeamPipeWidth"                material="Beryllium" name="VertexInnerBe" />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="BePartEnd_z"  rMin1="CentralBeamPipe_rmax"  rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"      rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone"  rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017" material="Beryllium" name="FirstConeBe" />
+
+        </detector>
+
+	<detector name="BeamPipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" vis="BeamPipeVis" >
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <parameter crossingangle="CrossingAngle" />
+
+
+            <comment>Golden foil in the inner part of the Be beampipe</comment>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"    rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance"                material="Gold" name="VertexInnerGold"  />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="BePartEnd_z"  rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"      rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance+(BePartEnd_z-CentralBeamPipe_zmax)*0.017" material="Gold" name="FirstConeGold" />
+
+        <comment>Part of beampipe made of Copper</comment>
+        
+            <section type="Center" start="BePartEnd_z"  end="SeparatedBeamPipe_z"  rMin1="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"      rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017" material="Copper" name="CopperCone" />
+
+
+
+
+<!-- Fix 2020.04.08 : -->
+            <section type="PunchedCenter"        start="SeparatedBeamPipe_z" end="SeparatedBeamPipe_z+3*mm"    rMin1="SeparatedBeamPipe_rmax"      rMin2="SeparatedBeamPipe_rmax"       rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"     rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017 + 3*mm*0.017" material="Copper"     name="SplitVacChambers"/>
+
+
+             <section type="DnstreamClippedFront" start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="DownStreamBeamPipe_1"/>
+
+          
+<!-- upstream beam-pipe, without the mask : -->
+<!--
+	   <section type="UpstreamClippedFront"  start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_1"/>
+-->
+
+
+<!-- 2020.04.08 : reduce the BP radius in order to add the mask : -->
+           <section type="UpstreamClippedFront"  start="SeparatedBeamPipe_z+3.01*mm" end="MiddleOfSRMask_z -3*cm" rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_1"/>
+
+           <section type="Upstream" start="MiddleOfSRMask_z -3*cm" end="MiddleOfSRMask_z -1*cm" rMin1="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm" rMin2="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax2="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" material="Copper"      name="UpStreamBeamPipe_2" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -1*cm" end="MiddleOfSRMask_z +1*cm" rMin1="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax1="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" rMin2="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax2="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" material="Copper"      name="UpStreamBeamPipe_3" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +1*cm" end="MiddleOfSRMask_z +3*cm" rMin1="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax1="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" rMin2="SeparatedBeamPipe_rmax" rMax2="SeparatedBeamPipe_rmax+1*mm" material="Copper"      name="UpStreamBeamPipe_4" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +3*cm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_5" />
+
+</detector>
+
+<!-- 2020.04.08 : Synch Radiation mask (symmetyric in phi for the while) -->
+
+<comment>Synch Radiation mask inside the beam-pipe, at z = 2.1 m </comment>
+<detector name="SynchRadMask" type="Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -3*cm" end="MiddleOfSRMask_z -1*cm" rMin1="SeparatedBeamPipe_rmax +1*mm + mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon" rMin2="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm +2* mask_epsilon" material="Tungsten"      name="UpStreamBeamPipe_SRmask_1" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -1*cm" end="MiddleOfSRMask_z +1*cm" rMin1="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon " rMin2="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm + 2*mask_epsilon" material="Tungsten"    name="UpStreamBeamPipe_SRmask_2" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +1*cm" end="MiddleOfSRMask_z +3*cm" rMin1="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize +mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm + 2*mask_epsilon" rMin2="SeparatedBeamPipe_rmax +1*mm + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon" material="Tungsten"      name="UpStreamBeamPipe_SRmask_3" />
+
+</detector>
+
+
+
+<comment>Full Cone Tungsten Shield</comment>
+<detector name="BeamPipeShield" type="Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+        <comment>Before HOM space</comment>
+        <section type="PunchedCenter"        
+        start="LumiCal_max_z + 5*mm" end="1197.5*mm" 
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm" 
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (LumiCal_max_z + 5*mm )*0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (1197.5*mm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield_BH2" />
+
+
+
+        <comment>After HOM space (1197.5*m - 1298.7*mm) +18 cm as solenoid is now closer to IP </comment>
+        <section type="PunchedCenter"        
+        start="1298.7*mm" end="QD0_min_z + 18*cm" 
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm" 
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (1298.7*mm )*0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (QD0_min_z + 18*cm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield_AH" />
+
+        </detector>
+<comment>Asymmetric Tungsten Shield no Rotation</comment>
+
+<detector name="BeamPipeShield_noRot" type="Mask_o1_v01_noRot" insideTrackingVolume="true" vis="TantalumVis"  >
+        <parameter crossingangle="CrossingAngle" />
+
+        <section type="Center"        
+        start="500*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (500.0*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (500.0*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + TopFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="326*degree"
+        Phi2="34*degree"      
+      
+        material="Tungsten" name="TaShieldTopPart" />
+
+	<comment>was 370</comment>
+        <section type="Center"        
+        start="330*mm" end="500*mm" 
+        rMin1="CentralBeamPipe_rmax + (330*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (500*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (330*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMax2="CentralBeamPipe_rmax + (500*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + TopFillerShieldWidth"
+        Phi1="326*degree"
+        Phi2="34*degree"      
+      
+        material="Tungsten" name="TaShieldTopPart2" />
+
+
+	<comment>one degree less, to fit lumical window</comment>
+        <section type="Center"        
+        start="600*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + SideFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="34*degree"
+        Phi2="70*degree"      
+      
+        material="Tungsten" name="TaShieldFiller1" />
+
+        <section type="Center"        
+        start="600*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + SideFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="291*degree"
+        Phi2="326*degree" 
+
+      
+        material="Tungsten" name="TaShieldFiller2" />
+
+
+      </detector>
+
+    </detectors>
+</lccdd>

--- a/Detector/DetFCCeeCommon/compact/Beampipe_with_notch_noShield.xml
+++ b/Detector/DetFCCeeCommon/compact/Beampipe_with_notch_noShield.xml
@@ -55,14 +55,26 @@
 
         <comment>Part of beampipe made of Copper</comment>
         
-            <section type="Center" start="BePartEnd_z"  end="SeparatedBeamPipe_z"  rMin1="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"      rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017" material="Copper" name="CopperCone" />
+            <section type="Center" start="BePartEnd_z"  end="SeparatedBeamPipe_z"  
+		     rMin1="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  
+		     rMin2="SeparatedBeamPipe_rmax+0.015*SeparatedBeamPipe_z"      
+		     rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  
+		     rMax2="SeparatedBeamPipe_rmax+BeamPipeWidthFirstCone+0.015*SeparatedBeamPipe_z" 
+		     material="Copper" name="CopperCone" />
 
-
+<!--rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"
+    rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"-->
 
 
 <!-- Fix 2020.04.08 : -->
-            <section type="PunchedCenter"        start="SeparatedBeamPipe_z" end="SeparatedBeamPipe_z+3*mm"    rMin1="SeparatedBeamPipe_rmax"      rMin2="SeparatedBeamPipe_rmax"       rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"     rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017 + 3*mm*0.017" material="Copper"     name="SplitVacChambers"/>
+            <section type="PunchedCenter"        start="SeparatedBeamPipe_z" end="SeparatedBeamPipe_z+3*mm"    
+		     rMin1="SeparatedBeamPipe_rmax"      rMin2="SeparatedBeamPipe_rmax"       
+		     rMax1="SeparatedBeamPipe_rmax+0.015*(SeparatedBeamPipe_z+3*mm)"
+		     rMax2="SeparatedBeamPipe_rmax+BeamPipeWidthFirstCone+0.015*(SeparatedBeamPipe_z+3*mm)" 
+		     material="Copper"     name="SplitVacChambers"/>
 
+<!-- rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"
+     rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017 + 3*mm*0.017" -->
 
              <section type="DnstreamClippedFront" start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="DownStreamBeamPipe_1"/>
 

--- a/Detector/DetFCCeeCommon/compact/Beampipe_with_notch_noShield.xml
+++ b/Detector/DetFCCeeCommon/compact/Beampipe_with_notch_noShield.xml
@@ -1,0 +1,187 @@
+<lccdd>
+
+  <info name="FCCee"
+        title="FCCee Beam pipe: taken corresponding to CLD: Beampipe_o4_v04_noNotch_W_n02.xml"
+        author="nalipour taken from lcgeo"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>A beampipe for FCCee detector based on CLD</comment>
+  </info>
+    
+    <!--  Definition of global dictionary constants          -->
+    <define>
+      <constant name="beampipegoldwidth" value="BeamPipeGoldWidth"/>
+      <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
+        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
+    </display>
+    
+    
+    <detectors>
+
+        <comment>Part of beampipe made of Beryllium</comment>
+        
+        <detector name="BeBeampipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" nocore="true" vis="BeamPipeVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax"  rMin2="CentralBeamPipe_rmax"    rMax1="CentralBeamPipe_rmax+BeamPipeWidth"  rMax2="CentralBeamPipe_rmax+BeamPipeWidth"                material="Beryllium" name="VertexInnerBe" />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="BePartEnd_z"  rMin1="CentralBeamPipe_rmax"  rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"      rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone"  rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017" material="Beryllium" name="FirstConeBe" />
+
+        </detector>
+
+	<detector name="BeamPipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" vis="BeamPipeVis" >
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <parameter crossingangle="CrossingAngle" />
+
+
+            <comment>Golden foil in the inner part of the Be beampipe</comment>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"    rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance"                material="Gold" name="VertexInnerGold"  />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="BePartEnd_z"  rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"      rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance+(BePartEnd_z-CentralBeamPipe_zmax)*0.017" material="Gold" name="FirstConeGold" />
+
+        <comment>Part of beampipe made of Copper</comment>
+        
+            <section type="Center" start="BePartEnd_z"  end="SeparatedBeamPipe_z"  rMin1="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  rMin2="CentralBeamPipe_rmax+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"      rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017"  rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017" material="Copper" name="CopperCone" />
+
+
+
+
+<!-- Fix 2020.04.08 : -->
+            <section type="PunchedCenter"        start="SeparatedBeamPipe_z" end="SeparatedBeamPipe_z+3*mm"    rMin1="SeparatedBeamPipe_rmax"      rMin2="SeparatedBeamPipe_rmax"       rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017"     rMax2="CentralBeamPipe_rmax+BeamPipeWidthFirstCone+(BePartEnd_z-CentralBeamPipe_zmax)*0.017+(SeparatedBeamPipe_z-BePartEnd_z)*0.017 + 3*mm*0.017" material="Copper"     name="SplitVacChambers"/>
+
+
+             <section type="DnstreamClippedFront" start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="DownStreamBeamPipe_1"/>
+
+          
+<!-- upstream beam-pipe, without the mask : -->
+<!--
+	   <section type="UpstreamClippedFront"  start="SeparatedBeamPipe_z+3.01*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_1"/>
+-->
+
+
+<!-- 2020.04.08 : reduce the BP radius in order to add the mask : -->
+           <section type="UpstreamClippedFront"  start="SeparatedBeamPipe_z+3.01*mm" end="MiddleOfSRMask_z -3*cm" rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_1"/>
+
+           <section type="Upstream" start="MiddleOfSRMask_z -3*cm" end="MiddleOfSRMask_z -1*cm" rMin1="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm" rMin2="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax2="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" material="Copper"      name="UpStreamBeamPipe_2" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -1*cm" end="MiddleOfSRMask_z +1*cm" rMin1="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax1="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" rMin2="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax2="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" material="Copper"      name="UpStreamBeamPipe_3" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +1*cm" end="MiddleOfSRMask_z +3*cm" rMin1="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax1="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" rMin2="SeparatedBeamPipe_rmax" rMax2="SeparatedBeamPipe_rmax+1*mm" material="Copper"      name="UpStreamBeamPipe_4" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +3*cm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_5" />
+
+</detector>
+
+<!-- 2020.04.08 : Synch Radiation mask (symmetyric in phi for the while) -->
+
+<comment>Synch Radiation mask inside the beam-pipe, at z = 2.1 m </comment>
+<detector name="SynchRadMask" type="Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -3*cm" end="MiddleOfSRMask_z -1*cm" rMin1="SeparatedBeamPipe_rmax +1*mm + mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon" rMin2="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm +2* mask_epsilon" material="Tungsten"      name="UpStreamBeamPipe_SRmask_1" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -1*cm" end="MiddleOfSRMask_z +1*cm" rMin1="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon " rMin2="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm + 2*mask_epsilon" material="Tungsten"    name="UpStreamBeamPipe_SRmask_2" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +1*cm" end="MiddleOfSRMask_z +3*cm" rMin1="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize +mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm + 2*mask_epsilon" rMin2="SeparatedBeamPipe_rmax +1*mm + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon" material="Tungsten"      name="UpStreamBeamPipe_SRmask_3" />
+
+</detector>
+
+
+<!--
+<comment>Full Cone Tungsten Shield</comment>
+<detector name="BeamPipeShield" type="Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+        <comment>Before HOM space</comment>
+        <section type="PunchedCenter"        
+        start="LumiCal_max_z + 5*mm" end="1197.5*mm" 
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm" 
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (LumiCal_max_z + 5*mm )*0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (1197.5*mm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield_BH2" />
+
+
+
+        <comment>After HOM space (1197.5*m - 1298.7*mm) +18 cm as solenoid is now closer to IP </comment>
+        <section type="PunchedCenter"        
+        start="1298.7*mm" end="QD0_min_z + 18*cm" 
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm" 
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (1298.7*mm )*0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (QD0_min_z + 18*cm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield_AH" />
+
+        </detector>
+<comment>Asymmetric Tungsten Shield no Rotation</comment>
+
+<detector name="BeamPipeShield_noRot" type="Mask_o1_v01_noRot" insideTrackingVolume="true" vis="TantalumVis"  >
+        <parameter crossingangle="CrossingAngle" />
+
+        <section type="Center"        
+        start="500*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (500.0*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (500.0*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + TopFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="326*degree"
+        Phi2="34*degree"      
+      
+        material="Tungsten" name="TaShieldTopPart" />
+
+	<comment>was 370</comment>
+        <section type="Center"        
+        start="330*mm" end="500*mm" 
+        rMin1="CentralBeamPipe_rmax + (330*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (500*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (330*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMax2="CentralBeamPipe_rmax + (500*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + TopFillerShieldWidth"
+        Phi1="326*degree"
+        Phi2="34*degree"      
+      
+        material="Tungsten" name="TaShieldTopPart2" />
+
+
+	<comment>one degree less, to fit lumical window</comment>
+        <section type="Center"        
+        start="600*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + SideFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="34*degree"
+        Phi2="70*degree"      
+      
+        material="Tungsten" name="TaShieldFiller1" />
+
+        <section type="Center"        
+        start="600*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + SideFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="291*degree"
+        Phi2="326*degree" 
+
+      
+        material="Tungsten" name="TaShieldFiller2" />
+
+
+      </detector>
+-->
+    </detectors>
+</lccdd>

--- a/Detector/DetFCCeeCommon/compact/FFQuads.xml
+++ b/Detector/DetFCCeeCommon/compact/FFQuads.xml
@@ -1,0 +1,192 @@
+<lccdd>
+    
+  <info name="FCCee"
+        title="FCCee LumiCal: taken correspoding to CLD: LumiCal_o3_v02_03.xml"
+        author="from ILCSOFT/lcgeo/FCCee/compact/FCCee_o1_v04"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>LumiCal for FCCee detector</comment>
+  </info>
+
+
+    <define>
+            <constant name="LumiCal_cell_size" value="1.81*mm"/>
+    </define>
+    
+    <readouts>
+        <readout name="LumiCalCollection">
+	    <segmentation type="PolarGridRPhi"
+			  grid_size_r="(LumiCal_outer_radius-LumiCal_inner_radius)/32"
+			  grid_size_phi="360/32*degree"
+			  offset_r="LumiCal_inner_radius + (LumiCal_outer_radius-LumiCal_inner_radius)/64"
+			  />
+	    <id>system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16</id>
+        </readout>
+    </readouts>
+ 
+<!--offset_r="LumiCal_inner_radius+0.5*((LumiCal_outer_radius-LumiCal_inner_radius)/32)"-->
+   
+    <detectors>
+        <detector name="LumiCal" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCal" readout="LumiCalCollection" insideTrackingVolume="false" >
+            
+            <envelope vis="LCALVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz"/>
+                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
+                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz"/>
+                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+            
+            <parameter crossingangle="CrossingAngle" />
+            
+            <dimensions inner_r = "LumiCal_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_outer_radius"
+            modules = "8"
+            phi_sectors = "4"
+            r_sectors = "32"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+            
+            
+            <layer repeat="25" vis="SeeThrough">
+                <slice material = "TungstenDens24" thickness = "3.5*mm" 		   vis="BCLayerVis1" />
+                <slice material = "Kapton"     thickness = "0.28*mm" />
+                <slice material = "Silicon" thickness = "0.32*mm" 	sensitive = "yes"  vis="BCLayerVis2"/>
+                <slice material = "Copper"  thickness = "0.4*mm"                    vis="BCLayerVis3"/>
+            </layer>
+            
+            
+        </detector>
+
+        <detector name="LumiCalInstrumentation" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalInstrumentation" readout="LumiCalCollection" insideTrackingVolume="false" >
+            
+            <envelope vis="LCALInstrVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz"/>
+                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
+                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz"/>
+                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+            
+            <parameter crossingangle="CrossingAngle" />
+            
+            <dimensions inner_r = "LumiCal_Instr_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_Instr_outer_radius"
+            modules = "8"
+            phi_sectors = "4"
+            r_sectors = "32"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+            
+            
+            <layer repeat="25" vis="SeeThrough">
+                <slice material = "Aluminum" thickness = "2.0*mm" 	sensitive = "no"  vis="SupportVis"/>
+		<slice material = "Air" thickness = "2.5*mm" 	sensitive = "no"  vis="SupportVis"/>
+            </layer>
+            
+            
+        </detector>
+
+
+        <detector name="LumiCalCooling" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalCooling" readout="LumiCalCollection" insideTrackingVolume="false" >
+            
+            <envelope vis="LCALCoolVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz"/>
+                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
+                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz"/>
+                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+            
+            <parameter crossingangle="CrossingAngle" />
+            
+            <dimensions inner_r = "LumiCal_Cool_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_Cool_outer_radius"
+            modules = "8"
+            phi_sectors = "4"
+            r_sectors = "32"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+            
+            
+            <layer repeat="25" vis="SeeThrough">
+		<slice material = "Air" thickness = "4.5*mm" 	sensitive = "no"  vis="SupportVis"/>
+            </layer>
+            
+            
+        </detector>
+
+   <detector name="LumiCalBackShield" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalBackShield"  readout="LumiCalCollection" insideTrackingVolume="false" >
+      
+     <envelope vis="LCALShieldVis">
+       <shape type="BooleanShape" operation="union" material="Air">
+
+         <shape type="BooleanShape" operation="Intersection">
+           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz"/>
+           <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="LumiCal_max_z+LumiCal_shield_dz"/>
+           <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+         </shape>
+         <shape type="BooleanShape" operation="Intersection">
+           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz"/>
+           <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="-(LumiCal_max_z+LumiCal_shield_dz)"/>
+           <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+         </shape>
+
+       </shape>
+     </envelope>
+     
+     <parameter crossingangle="CrossingAngle" />
+     
+
+     
+     <dimensions inner_r = "LumiCal_Shield_inner_radius"
+		 outer_r = "LumiCal_Shield_outer_radius"
+		 outer_z = "LumiCal_max_z+2*LumiCal_shield_dz"
+		 inner_z = "LumiCal_max_z"/>
+            
+            
+            <layer repeat="1" vis="SeeThrough">
+                <slice material = "TungstenDens24" thickness = "3.5*mm" 	sensitive = "no"  vis="SupportVis"/>
+            </layer>
+            
+            
+        </detector>
+
+    </detectors>
+    
+</lccdd>
+
+

--- a/Detector/DetFCCeeCommon/compact/FFQuads.xml
+++ b/Detector/DetFCCeeCommon/compact/FFQuads.xml
@@ -1,192 +1,44 @@
 <lccdd>
-    
+
   <info name="FCCee"
-        title="FCCee LumiCal: taken correspoding to CLD: LumiCal_o3_v02_03.xml"
-        author="from ILCSOFT/lcgeo/FCCee/compact/FCCee_o1_v04"
+        title="final focusing quadrupoles"
+        author="Andrea Ciarma - FFQs design Mike Koratzinos"
         url="no"
         status="development"
         version="1.0">
-    <comment>LumiCal for FCCee detector</comment>
+    <comment> Final Focusing Quadrupoles simplified model </comment>
   </info>
 
+  <detectors>
 
-    <define>
-            <constant name="LumiCal_cell_size" value="1.81*mm"/>
-    </define>
-    
-    <readouts>
-        <readout name="LumiCalCollection">
-	    <segmentation type="PolarGridRPhi"
-			  grid_size_r="(LumiCal_outer_radius-LumiCal_inner_radius)/32"
-			  grid_size_phi="360/32*degree"
-			  offset_r="LumiCal_inner_radius + (LumiCal_outer_radius-LumiCal_inner_radius)/64"
-			  />
-	    <id>system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16</id>
-        </readout>
-    </readouts>
- 
-<!--offset_r="LumiCal_inner_radius+0.5*((LumiCal_outer_radius-LumiCal_inner_radius)/32)"-->
-   
-    <detectors>
-        <detector name="LumiCal" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCal" readout="LumiCalCollection" insideTrackingVolume="false" >
-            
-            <envelope vis="LCALVis">
-                <shape type="BooleanShape" operation="union" material="Air">
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz"/>
-                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
-                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
-                    </shape>
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz"/>
-                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
-                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
-                    </shape>
-                </shape>
-            </envelope>
-            
-            <parameter crossingangle="CrossingAngle" />
-            
-            <dimensions inner_r = "LumiCal_inner_radius"
-            inner_z = "LumiCal_min_z"
-            outer_r = "LumiCal_outer_radius"
-            modules = "8"
-            phi_sectors = "4"
-            r_sectors = "32"
-            phi_gap = "2*mm"
-            r_gap = "2*mm" />
-            
-            
-            <layer repeat="25" vis="SeeThrough">
-                <slice material = "TungstenDens24" thickness = "3.5*mm" 		   vis="BCLayerVis1" />
-                <slice material = "Kapton"     thickness = "0.28*mm" />
-                <slice material = "Silicon" thickness = "0.32*mm" 	sensitive = "yes"  vis="BCLayerVis2"/>
-                <slice material = "Copper"  thickness = "0.4*mm"                    vis="BCLayerVis3"/>
-            </layer>
-            
-            
-        </detector>
-
-        <detector name="LumiCalInstrumentation" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalInstrumentation" readout="LumiCalCollection" insideTrackingVolume="false" >
-            
-            <envelope vis="LCALInstrVis">
-                <shape type="BooleanShape" operation="union" material="Air">
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz"/>
-                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
-                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
-                    </shape>
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz"/>
-                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
-                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
-                    </shape>
-                </shape>
-            </envelope>
-            
-            <parameter crossingangle="CrossingAngle" />
-            
-            <dimensions inner_r = "LumiCal_Instr_inner_radius"
-            inner_z = "LumiCal_min_z"
-            outer_r = "LumiCal_Instr_outer_radius"
-            modules = "8"
-            phi_sectors = "4"
-            r_sectors = "32"
-            phi_gap = "2*mm"
-            r_gap = "2*mm" />
-            
-            
-            <layer repeat="25" vis="SeeThrough">
-                <slice material = "Aluminum" thickness = "2.0*mm" 	sensitive = "no"  vis="SupportVis"/>
-		<slice material = "Air" thickness = "2.5*mm" 	sensitive = "no"  vis="SupportVis"/>
-            </layer>
-            
-            
-        </detector>
-
-
-        <detector name="LumiCalCooling" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalCooling" readout="LumiCalCollection" insideTrackingVolume="false" >
-            
-            <envelope vis="LCALCoolVis">
-                <shape type="BooleanShape" operation="union" material="Air">
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz"/>
-                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
-                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
-                    </shape>
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz"/>
-                        <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
-                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
-                    </shape>
-                </shape>
-            </envelope>
-            
-            <parameter crossingangle="CrossingAngle" />
-            
-            <dimensions inner_r = "LumiCal_Cool_inner_radius"
-            inner_z = "LumiCal_min_z"
-            outer_r = "LumiCal_Cool_outer_radius"
-            modules = "8"
-            phi_sectors = "4"
-            r_sectors = "32"
-            phi_gap = "2*mm"
-            r_gap = "2*mm" />
-            
-            
-            <layer repeat="25" vis="SeeThrough">
-		<slice material = "Air" thickness = "4.5*mm" 	sensitive = "no"  vis="SupportVis"/>
-            </layer>
-            
-            
-        </detector>
-
-   <detector name="LumiCalBackShield" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalBackShield"  readout="LumiCalCollection" insideTrackingVolume="false" >
+    <detector name="QC1L1" type="MaterialEnvelope_o1_v01" vis="SeeThrough" id="DetID_FFQs" insideTrackingVolume="false" >
+	<parameter crossingangle="CrossingAngle" />
+      <envelope vis="ECALVis">
       
-     <envelope vis="LCALShieldVis">
-       <shape type="BooleanShape" operation="union" material="Air">
+     	 <shape type="BooleanShape" operation="union" material="Iron">
+      		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="42/2*mm" rmax1="64/2*mm" rmin2="42/2*mm" rmax2="64/2*mm" z="700/2*mm" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(2.2+0.7/2)*m" y="0" z="(2.2+0.7/2)*m"/>
+          		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="42/2*mm" rmax1="64/2*mm" rmin2="42/2*mm" rmax2="64/2*mm" z="700/2*mm" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(2.2+0.7/2)*m" y="0" z="-(2.2+0.7/2)*m"/>
+          		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+	</shape>
+          
+  
 
-         <shape type="BooleanShape" operation="Intersection">
-           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz"/>
-           <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="LumiCal_max_z+LumiCal_shield_dz"/>
-           <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
-         </shape>
-         <shape type="BooleanShape" operation="Intersection">
-           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz"/>
-           <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="-(LumiCal_max_z+LumiCal_shield_dz)"/>
-           <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
-         </shape>
+              </envelope>
 
-       </shape>
-     </envelope>
-     
-     <parameter crossingangle="CrossingAngle" />
-     
+    </detector>
 
-     
-     <dimensions inner_r = "LumiCal_Shield_inner_radius"
-		 outer_r = "LumiCal_Shield_outer_radius"
-		 outer_z = "LumiCal_max_z+2*LumiCal_shield_dz"
-		 inner_z = "LumiCal_max_z"/>
-            
-            
-            <layer repeat="1" vis="SeeThrough">
-                <slice material = "TungstenDens24" thickness = "3.5*mm" 	sensitive = "no"  vis="SupportVis"/>
-            </layer>
-            
-            
-        </detector>
-
-    </detectors>
-    
+ 
+  </detectors>
+  
 </lccdd>
 
 

--- a/Detector/DetFCCeeCommon/compact/FFQuads.xml
+++ b/Detector/DetFCCeeCommon/compact/FFQuads.xml
@@ -27,30 +27,30 @@
 	<parameter crossingangle="CrossingAngle" />
       <envelope vis="ECALVis">
       
-     	 <shape type="BooleanShape" operation="union" material="Iron">
+     	 <shape type="BooleanShape" operation="union" material="FFQMaterial">
 	 
 	 	<!-- QC1L1 -->
       		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" />
           		<position x="tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="(QC1L1_start+QC1L1_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" />
           		<position x="tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="-(QC1L1_start+QC1L1_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2"   />
           		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="(QC1L1_start+QC1L1_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2"   />
           		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="-(QC1L1_start+QC1L1_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
@@ -58,25 +58,25 @@
 		<!-- QC1L2 -->
       		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2"   />
           		<position x="tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="(QC1L2_start+QC1L2_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2"   />
           		<position x="tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="-(QC1L2_start+QC1L2_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2"   />
           		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="(QC1L2_start+QC1L2_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2"   />
           		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="-(QC1L2_start+QC1L2_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
@@ -84,25 +84,25 @@
 		<!-- QC1L23-->
       		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2"   />
           		<position x="tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="(QC1L3_start+QC1L3_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2"   />
           		<position x="tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="-(QC1L3_start+QC1L3_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2"   />
           		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="(QC1L3_start+QC1L3_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2"   />
           		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="-(QC1L3_start+QC1L3_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>

--- a/Detector/DetFCCeeCommon/compact/FFQuads.xml
+++ b/Detector/DetFCCeeCommon/compact/FFQuads.xml
@@ -8,27 +8,112 @@
         version="1.0">
     <comment> Final Focusing Quadrupoles simplified model </comment>
   </info>
+  
+  <define>
+    <!--  Definition of global dictionary constants          -->
+      <constant name="QC1_rmin" value="42/2*mm"/>
+      <constant name="QC1_rmax" value="64/2*mm"/>
+      <constant name="QC1L1_len" value="700*mm"/>
+      <constant name="QC1L2_len" value="1250*mm"/>
+      <constant name="QC1L3_len" value="1250*mm"/>
+      <constant name="QC1L1_start" value="2200*mm"/>
+      <constant name="QC1L2_start" value="QC1L1_start+QC1L1_len+8*cm"/>
+      <constant name="QC1L3_start" value="QC1L2_start+QC1L2_len+8*cm"/>    
+  </define>
 
   <detectors>
 
-    <detector name="QC1L1" type="MaterialEnvelope_o1_v01" vis="SeeThrough" id="DetID_FFQs" insideTrackingVolume="false" >
+    <detector name="QC1" type="MaterialEnvelope_o1_v01" vis="SeeThrough" id="DetID_FFQs" insideTrackingVolume="false" >
 	<parameter crossingangle="CrossingAngle" />
       <envelope vis="ECALVis">
       
      	 <shape type="BooleanShape" operation="union" material="Iron">
+	 
+	 	<!-- QC1L1 -->
       		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="42/2*mm" rmax1="64/2*mm" rmin2="42/2*mm" rmax2="64/2*mm" z="700/2*mm" material="Iron" />
-          		<position x="tan(0.5*abs(CrossingAngle))*(2.2+0.7/2)*m" y="0" z="(2.2+0.7/2)*m"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="(QC1L1_start+QC1L1_len/2)"/>
           		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
 		<shape type="BooleanShape" operation="Intersection">
 			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-      			<shape type="Cone" rmin1="42/2*mm" rmax1="64/2*mm" rmin2="42/2*mm" rmax2="64/2*mm" z="700/2*mm" material="Iron" />
-          		<position x="tan(0.5*abs(CrossingAngle))*(2.2+0.7/2)*m" y="0" z="-(2.2+0.7/2)*m"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="-(QC1L1_start+QC1L1_len/2)"/>
           		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
 		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+          		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="(QC1L1_start+QC1L1_len/2)"/>
+          		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L1_len/2" material="Iron" />
+          		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L1_start+QC1L1_len/2)" y="0" z="-(QC1L1_start+QC1L1_len/2)"/>
+          		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		
+		<!-- QC1L2 -->
+      		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="(QC1L2_start+QC1L2_len/2)"/>
+          		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="-(QC1L2_start+QC1L2_len/2)"/>
+          		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+          		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="(QC1L2_start+QC1L2_len/2)"/>
+          		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L2_len/2" material="Iron" />
+          		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L2_start+QC1L2_len/2)" y="0" z="-(QC1L2_start+QC1L2_len/2)"/>
+          		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		
+		<!-- QC1L23-->
+      		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="(QC1L3_start+QC1L3_len/2)"/>
+          		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+          		<position x="tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="-(QC1L3_start+QC1L3_len/2)"/>
+          		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+          		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="(QC1L3_start+QC1L3_len/2)"/>
+          		<rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		<shape type="BooleanShape" operation="Intersection">
+			<shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+      			<shape type="Cone" rmin1="QC1_rmin" rmax1="QC1_rmax" rmin2="QC1_rmin" rmax2="QC1_rmax" z="QC1L3_len/2" material="Iron" />
+          		<position x="-tan(0.5*abs(CrossingAngle))*(QC1L3_start+QC1L3_len/2)" y="0" z="-(QC1L3_start+QC1L3_len/2)"/>
+          		<rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+		</shape>
+		
+		
+		
+		
+		
 	</shape>
+	
+	
           
   
 

--- a/Detector/DetFCCeeCommon/compact/FFQuads_sens.xml
+++ b/Detector/DetFCCeeCommon/compact/FFQuads_sens.xml
@@ -34,21 +34,25 @@
 
   </define>
 
-
+  <readouts>
+    <readout name="FFQ_Readout">
+      <id>system:8</id>
+    </readout>
+  </readouts>
 
 <detectors>
-    <detector name="QC1" type="DD4hep_Mask_o1_v01" vis="KICKVis" id="DetID_FFQs">
+    <detector name="QC1" type="DD4hep_Mask_o1_v01" vis="KICKVis" id="DetID_FFQs" readout="FFQ_Readout">
       <parameter crossingangle="CrossingAngle" />
       <envelope vis="KICKVis">
         <shape type="Assembly"/>
       </envelope>
             <!--             &A                                Z1                  Z2                    RIn1                       RIn2               ROut1                        ROut2              Material          phi1        phi2       -->
-            <section type="Upstream"               start="QC1L1_start"    end="QC1L1_start+QC1L1_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L1u" />
-            <section type="Dnstream"               start="QC1L1_start"    end="QC1L1_start+QC1L1_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L1d" />
-            <section type="Upstream"               start="QC1L2_start"    end="QC1L2_start+QC1L2_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L2u" />
-            <section type="Dnstream"               start="QC1L2_start"    end="QC1L2_start+QC1L2_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L2d" />
-            <section type="Upstream"               start="QC1L3_start"    end="QC1L3_start+QC1L3_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L3u" />
-            <section type="Dnstream"               start="QC1L3_start"    end="QC1L3_start+QC1L3_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L3d" />
+           <section type="Upstream"               start="QC1L1_start"    end="QC1L1_start+QC1L1_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L1u" sensitive="tracker"/>
+           <section type="Dnstream"               start="QC1L1_start"    end="QC1L1_start+QC1L1_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L1d" sensitive="tracker"/>
+           <section type="Upstream"               start="QC1L2_start"    end="QC1L2_start+QC1L2_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L2u" sensitive="tracker"/>
+            <section type="Dnstream"               start="QC1L2_start"    end="QC1L2_start+QC1L2_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L2d" sensitive="tracker"/>
+            <section type="Upstream"               start="QC1L3_start"    end="QC1L3_start+QC1L3_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L3u" sensitive="tracker"/>
+            <section type="Dnstream"               start="QC1L3_start"    end="QC1L3_start+QC1L3_len" rMin1="QC1_rmin"          rMin2="QC1_rmin"  rMax1="QC1_rmax"   rMax2="QC1_rmax"  material="FFQMaterial" name="QC1L3d" sensitive="tracker"/>
         </detector>   
 </detectors>
 

--- a/Detector/DetFCCeeCommon/compact/FFQuads_sens.xml
+++ b/Detector/DetFCCeeCommon/compact/FFQuads_sens.xml
@@ -36,7 +36,7 @@
 
   <readouts>
     <readout name="FFQ_Readout">
-      <id>system:8</id>
+      <id>${GlobalTrackerReadoutID}</id>-->
     </readout>
   </readouts>
 

--- a/Detector/DetFCCeeCommon/compact/SRshielding.xml
+++ b/Detector/DetFCCeeCommon/compact/SRshielding.xml
@@ -1,0 +1,97 @@
+<lccdd>
+
+  <info name="FCCee"
+        title="FCCee Beam pipe Shielding: taken corresponding to CLD: Beampipe.xml"
+        author="aciarma"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>Beam Pipe Tungsten Shieldings</comment>
+  </info>
+        
+    
+    <detectors>
+
+<comment>Full Cone Tungsten Shield</comment>
+<detector name="BeamPipeShield" type="Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+        <comment>Before HOM space</comment>
+        <section type="PunchedCenter"        
+        start="LumiCal_max_z + 5*mm" end="1197.5*mm" 
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm" 
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (LumiCal_max_z + 5*mm )*0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (1197.5*mm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield_BH2" />
+
+
+
+        <comment>After HOM space (1197.5*m - 1298.7*mm) +18 cm as solenoid is now closer to IP </comment>
+        <section type="PunchedCenter"        
+        start="1298.7*mm" end="QD0_min_z + 18*cm" 
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm" 
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (1298.7*mm )*0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (QD0_min_z + 18*cm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield_AH" />
+
+</detector>
+<comment>Asymmetric Tungsten Shield no Rotation</comment>
+
+<detector name="BeamPipeShield_noRot" type="Mask_o1_v01_noRot" insideTrackingVolume="true" vis="TantalumVis"  >
+        <parameter crossingangle="CrossingAngle" />
+
+        <section type="Center"        
+        start="500*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (500.0*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (500.0*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + TopFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm-CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="326*degree"
+        Phi2="34*degree"      
+      
+        material="Tungsten" name="TaShieldTopPart" />
+
+	<comment>was 370</comment>
+        <section type="Center"        
+        start="330*mm" end="500*mm" 
+        rMin1="CentralBeamPipe_rmax + (330*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (500*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (330*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMax2="CentralBeamPipe_rmax + (500*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + TopFillerShieldWidth"
+        Phi1="326*degree"
+        Phi2="34*degree"      
+      
+        material="Tungsten" name="TaShieldTopPart2" />
+
+
+	<comment>one degree less, to fit lumical window</comment>
+        <section type="Center"        
+        start="600*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + SideFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="34*degree"
+        Phi2="70*degree"      
+      
+        material="Tungsten" name="TaShieldFiller1" />
+
+        <section type="Center"        
+        start="600*mm" end="LumiCal_max_z + 4.9*mm" 
+        rMin1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"  
+        rMin2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm"           
+        rMax1="CentralBeamPipe_rmax + (600*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + SideFillerShieldWidth"  
+        rMax2="CentralBeamPipe_rmax + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax)*0.017 + BeamPipeWidthFirstCone + 0.1*mm + BeamPipeTantalShieldWidth"
+        Phi1="291*degree"
+        Phi2="326*degree" 
+
+      
+        material="Tungsten" name="TaShieldFiller2" />
+
+
+</detector>
+
+</detectors>
+</lccdd>

--- a/Detector/DetSensitive/include/DetSensitive/AggregateCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/AggregateCalorimeterSD.h
@@ -3,7 +3,7 @@
 
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 
 // FCCSW
 #include "DetCommon/Geant4CaloHit.h"

--- a/Detector/DetSensitive/include/DetSensitive/BirksLawCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/BirksLawCalorimeterSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_BIRKSLAWCALORIMETERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 
 // Geant
 #include "G4THitsCollection.hh"

--- a/Detector/DetSensitive/include/DetSensitive/FullParticleAbsorptionSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/FullParticleAbsorptionSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_FULLPARTICLEABSORPTIONSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 #include "DDSegmentation/Segmentation.h"
 
 // Geant

--- a/Detector/DetSensitive/include/DetSensitive/GflashCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/GflashCalorimeterSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_GFLASHCALORIMETERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 #include "DDSegmentation/Segmentation.h"
 
 // Geant

--- a/Detector/DetSensitive/include/DetSensitive/SimpleCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/SimpleCalorimeterSD.h
@@ -2,9 +2,7 @@
 #define DETSENSITIVE_SIMPLECALORIMETERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
-
-
+#include "DD4hep/Segmentations.h"
 
 // Geant
 #include "G4THitsCollection.hh"

--- a/Detector/DetSensitive/include/DetSensitive/SimpleDriftChamber.h
+++ b/Detector/DetSensitive/include/DetSensitive/SimpleDriftChamber.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_SIMPLEDRIFTCHAMBER_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 #include "DDSegmentation/Segmentation.h"
 
 // Geant

--- a/Detector/DetSensitive/include/DetSensitive/SimpleTrackerSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/SimpleTrackerSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_SIMPLETRACKERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 
 // Geant
 #include "G4THitsCollection.hh"


### PR DESCRIPTION
- Added FFQs simplified model, also in a sensitive version (can record hits)
- Implemented the version of the beam pipe with the SR mask, which has been extended from 5mm to 8mm in order to account for the smaller central part
- The tungsten shieldings has been moved to a separate file (they were in the beampipe.xml)
- Slight change to the conical beam pipe section before the separation, to correct an incongruence due to the small beam pipe
- Modified the master file FCCee_o2_v03.xml to account for these changes